### PR TITLE
Update Kinesis Firehose module to work with AWS provider versions 5.0 and later.

### DIFF
--- a/modules/cloudwatch-logs/USAGE.md
+++ b/modules/cloudwatch-logs/USAGE.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/kinesis-firehose/USAGE.md
+++ b/modules/kinesis-firehose/USAGE.md
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/kinesis-firehose/main.tf
+++ b/modules/kinesis-firehose/main.tf
@@ -15,15 +15,6 @@ resource "aws_kinesis_firehose_delivery_stream" "http_stream" {
   name        = var.name
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn   = aws_iam_role.firehose_s3_role.arn
-    bucket_arn = var.s3_failure_bucket_arn
-
-    buffer_size        = var.s3_buffer_size
-    buffer_interval    = var.s3_buffer_interval
-    compression_format = var.s3_compression_format
-  }
-
   http_endpoint_configuration {
     url                = "${var.uptrace_api_host}/api/v1/cloudwatch/${var.uptrace_event_type}"
     name               = "uptrace"
@@ -32,6 +23,15 @@ resource "aws_kinesis_firehose_delivery_stream" "http_stream" {
     s3_backup_mode     = var.s3_backup_mode
     buffering_size     = var.http_buffering_size
     buffering_interval = var.http_buffering_interval
+
+    s3_configuration {
+      role_arn   = aws_iam_role.firehose_s3_role.arn
+      bucket_arn = var.s3_failure_bucket_arn
+
+      buffering_size     = var.s3_buffer_size
+      buffering_interval = var.s3_buffer_interval
+      compression_format = var.s3_compression_format
+    }
 
     request_configuration {
       content_encoding = "GZIP"


### PR DESCRIPTION
The s3_configuration block was moved from the root of the aws_kinesis_firehose_delivery_stream definition into its http_endpoint_configuration block. This is a breaking change and necessitates AWS provider version 5.0 or later.