### PR TITLE
feat: add lambda transform for metrics

### DIFF
--- a/modules/cloudwatch-metrics/USAGE.md
+++ b/modules/cloudwatch-metrics/USAGE.md
@@ -34,6 +34,8 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_http_buffering_interval"></a> [http\_buffering\_interval](#input\_http\_buffering\_interval) | Kinesis Firehose http buffer interval, in seconds. | `number` | `60` | no |
 | <a name="input_http_buffering_size"></a> [http\_buffering\_size](#input\_http\_buffering\_size) | Kinesis Firehose http buffer size, in MiB. | `number` | `15` | no |
+| <a name="input_enable_lambda_transform"></a> [enable\_lambda\_transform](#input\_enable\_lambda\_transform) | Enable a Lambda transform on the Kinesis Firehose to preprocess and structure the metrics | `bool` | `false` | no |
+| <a name="input_lambda_transform_arn"></a> [lambda\_transform\_arn](#input\_lambda\_transform\_arn) | If enable\_lambda\_transform is set to true, specify a valid arn | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | A unique name for this CloudWatch Metric Stream. | `string` | `"uptrace-cloudwatch-metrics"` | no |
 | <a name="input_namespace_exclude_filters"></a> [namespace\_exclude\_filters](#input\_namespace\_exclude\_filters) | An optional list of CloudWatch Metric namespaces to exclude. If set, we'll only stream metrics that are not in these namespaces. Mutually exclusive with `namespace_include_filters`. | `list(string)` | `[]` | no |
 | <a name="input_namespace_include_filters"></a> [namespace\_include\_filters](#input\_namespace\_include\_filters) | An optional list of CloudWatch Metric namespaces to include. If set, we'll only stream metrics from these namespaces. Mutually exclusive with `namespace_exclude_filters`. | `list(string)` | `[]` | no |

--- a/modules/cloudwatch-metrics/main.tf
+++ b/modules/cloudwatch-metrics/main.tf
@@ -10,6 +10,9 @@ module "kfh" {
   http_buffering_size     = var.http_buffering_size
   http_buffering_interval = var.http_buffering_interval
 
+  enable_lambda_transform = var.enable_lambda_transform
+  lambda_transform_arn    = var.lambda_transform_arn
+
   s3_failure_bucket_arn = var.s3_failure_bucket_arn
   s3_backup_mode        = var.s3_backup_mode
   s3_buffer_size        = var.s3_buffer_size

--- a/modules/cloudwatch-metrics/variables.tf
+++ b/modules/cloudwatch-metrics/variables.tf
@@ -22,6 +22,19 @@ variable "uptrace_api_host" {
   description = "If you use a Secure Tenancy or other proxy, put its schema://host[:port] here."
 }
 
+# Optional variables for customer configuration
+variable "enable_lambda_transform" {
+  type        = bool
+  description = "Enable a Lambda transform on the Kinesis Firehose to preprocess and structure the logs"
+  default     = false
+}
+
+variable "lambda_transform_arn" {
+  type        = string
+  description = "If enable_lambda_transform is set to true, specify a valid arn"
+  default     = ""
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
Adding optional lambda transform variables for cloudwatch-metrics module, for now its only available for logs